### PR TITLE
Fix link to stevedore

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,4 +75,4 @@ See Also
 
 * `stevedore`_
 
-.. _stevedore: http://stevedore.readthedocs.org/en/latest/
+.. _stevedore: https://pypi.python.org/pypi/stevedore


### PR DESCRIPTION
The link to _stevedore_ on readthedocs is broken; I chose the PyPI URL instead of the OpenStack home because the former seems less likely to change.
