### PR TITLE
Added MANIFEST.in file to include README.rst and LICENSE file in source tarball.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.rst
+include announce.rst
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ setup(
     author='Doug Hellmann',
     author_email='doug@doughellmann.com',
 
+    license='ASL 2.0',
+
     url='https://github.com/dhellmann/entry_point_inspector',
 
     classifiers=[


### PR DESCRIPTION
- The current entry_point_inspector source tarball doesnot contains
  README.rst and LICENSE file. These two files are required as a part
  of CentOS/Fedora rpm packaging to order to include %license and %doc
  macro.
- Included license in setup.py
